### PR TITLE
Add verify route for auth token

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   preset: 'ts-jest',
   testEnvironment: 'node',
   setupFilesAfterEnv: ['<rootDir>/tests/setup/jestSetup.ts'],

--- a/routes/auth.ts
+++ b/routes/auth.ts
@@ -3,16 +3,16 @@ import bcrypt from 'bcrypt';
 import express from 'express';
 import jwt from 'jsonwebtoken';
 
-import { asyncHandler, asyncAuthHandler } from '../middleware/asyncHandler.js';
+import { asyncHandler, asyncAuthHandler } from '../middleware/asyncHandler';
 import {
   createError,
   createConflictError,
   createUnauthorizedError,
-} from '../middleware/errorHandler.js';
-import { validateRegister, validateLogin, sanitizeInput, securityHeaders } from '../middleware/validation.js';
-import { authRateLimit } from '../middleware/rateLimiting.js';
-import { logUserAction } from '../utils/secureLogger.js';
-import { requireAuth, type AuthRequest } from '../middleware/requireAuth.js';
+} from '../middleware/errorHandler';
+import { validateRegister, validateLogin, sanitizeInput, securityHeaders } from '../middleware/validation';
+import { authRateLimit } from '../middleware/rateLimiting';
+import { logUserAction } from '../utils/secureLogger';
+import { requireAuth, type AuthRequest } from '../middleware/requireAuth';
 
 const router = express.Router();
 const prisma = new PrismaClient();

--- a/routes/auth.ts
+++ b/routes/auth.ts
@@ -3,10 +3,7 @@ import bcrypt from 'bcrypt';
 import express from 'express';
 import jwt from 'jsonwebtoken';
 
-import {
-  asyncHandler,
-  asyncAuthHandler,
-} from '../middleware/asyncHandler';
+import { asyncHandler, asyncAuthHandler } from '../middleware/asyncHandler';
 import {
   createError,
   createConflictError,
@@ -20,10 +17,7 @@ import {
 } from '../middleware/validation';
 import { authRateLimit } from '../middleware/rateLimiting';
 import { logUserAction } from '../utils/secureLogger';
-import {
-  requireAuth,
-  type AuthRequest,
-} from '../middleware/requireAuth';
+import { requireAuth, type AuthRequest } from '../middleware/requireAuth';
 
 const router = express.Router();
 const prisma = new PrismaClient();

--- a/routes/auth.ts
+++ b/routes/auth.ts
@@ -5,7 +5,7 @@ import jwt from 'jsonwebtoken';
 
 import {
   asyncHandler,
-  asyncAuthHandler
+  asyncAuthHandler,
 } from '../middleware/asyncHandler';
 import {
   createError,
@@ -22,7 +22,7 @@ import { authRateLimit } from '../middleware/rateLimiting';
 import { logUserAction } from '../utils/secureLogger';
 import {
   requireAuth,
-  type AuthRequest
+  type AuthRequest,
 } from '../middleware/requireAuth';
 
 const router = express.Router();

--- a/routes/auth.ts
+++ b/routes/auth.ts
@@ -9,7 +9,11 @@ import {
   createConflictError,
   createUnauthorizedError,
 } from '../middleware/errorHandler';
-import { validateRegister, validateLogin, sanitizeInput, securityHeaders } from '../middleware/validation';
+import { validateRegister,
+        validateLogin,
+        sanitizeInput,
+        securityHeaders,
+       } from '../middleware/validation';
 import { authRateLimit } from '../middleware/rateLimiting';
 import { logUserAction } from '../utils/secureLogger';
 import { requireAuth, type AuthRequest } from '../middleware/requireAuth';

--- a/routes/auth.ts
+++ b/routes/auth.ts
@@ -129,8 +129,14 @@ router.get(
   '/verify',
   requireAuth,
   asyncAuthHandler(async (req: AuthRequest, res, next) => {
+    // Safely validate user ID from token
+    const userId = req.user?.id;
+    if (typeof userId !== 'string') {
+      return next(createUnauthorizedError('Invalid token'));
+    }
+
     const user = await prisma.user.findUnique({
-      where: { id: req.user!.id },
+      where: { id: userId },
       select: { id: true, email: true },
     });
 

--- a/routes/auth.ts
+++ b/routes/auth.ts
@@ -3,20 +3,27 @@ import bcrypt from 'bcrypt';
 import express from 'express';
 import jwt from 'jsonwebtoken';
 
-import { asyncHandler, asyncAuthHandler } from '../middleware/asyncHandler';
+import {
+  asyncHandler,
+  asyncAuthHandler
+} from '../middleware/asyncHandler';
 import {
   createError,
   createConflictError,
   createUnauthorizedError,
 } from '../middleware/errorHandler';
-import { validateRegister,
-        validateLogin,
-        sanitizeInput,
-        securityHeaders,
-       } from '../middleware/validation';
+import {
+  validateRegister,
+  validateLogin,
+  sanitizeInput,
+  securityHeaders,
+} from '../middleware/validation';
 import { authRateLimit } from '../middleware/rateLimiting';
 import { logUserAction } from '../utils/secureLogger';
-import { requireAuth, type AuthRequest } from '../middleware/requireAuth';
+import {
+  requireAuth,
+  type AuthRequest
+} from '../middleware/requireAuth';
 
 const router = express.Router();
 const prisma = new PrismaClient();


### PR DESCRIPTION
## Summary
- implement GET /api/auth/verify
- use `requireAuth` to check token validity
- return the user's id and email when token is valid

## Testing
- `npm run test:integration` *(fails: ReferenceError: module is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6862cb4f59908324846adc3b2341e24d