### PR TITLE
Fix stats endpoints empty response

### DIFF
--- a/routes/stats.ts
+++ b/routes/stats.ts
@@ -91,10 +91,10 @@ router.get(
         data.totalDistance > 0 ? Number((data.totalDuration / data.totalDistance).toFixed(2)) : 0,
     }));
 
-  // Handle empty data scenario
-  if (breakdownArray.length === 0) {
-    return res.json([]);
-  }
+    // Handle empty data scenario
+    if (breakdownArray.length === 0) {
+      return res.json([]);
+    }
 
     res.json(breakdownArray);
   })

--- a/routes/stats.ts
+++ b/routes/stats.ts
@@ -91,13 +91,10 @@ router.get(
         data.totalDistance > 0 ? Number((data.totalDuration / data.totalDistance).toFixed(2)) : 0,
     }));
 
-    // Handle empty data scenario
-    if (breakdownArray.length === 0) {
-      return res.json({
-        message: 'No running data found for type breakdown',
-        data: [],
-      });
-    }
+  // Handle empty data scenario
+  if (breakdownArray.length === 0) {
+    return res.json([]);
+  }
 
     res.json(breakdownArray);
   })
@@ -180,12 +177,7 @@ router.get(
 
     // Handle empty data scenario
     if (trendsData.length === 0) {
-      return res.json({
-        message: 'No running data found for the selected period',
-        data: [],
-        period,
-        daysBack,
-      });
+      return res.json([]);
     }
 
     res.json(trendsData);
@@ -239,10 +231,7 @@ router.get(
 
     // Handle empty data scenario
     if (records.length === 0) {
-      return res.json({
-        message: 'No personal records found - complete some runs to see your best times',
-        data: [],
-      });
+      return res.json([]);
     }
 
     res.json(records);


### PR DESCRIPTION
## Summary
- return empty arrays in /api/stats endpoints

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68631bcd71b08324a092e0053b1a36c2