### PR TITLE
fix(docker): rework images for vendored packages and tsx runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,46 @@
+# Keep the Docker build context small and deterministic. Anything the image
+# needs is either installed (npm ci) or built (postinstall / vite build)
+# inside the image, so we exclude host-generated trees to avoid shipping
+# stale artifacts or clobbering in-image installs via `COPY . .`.
+
+# Installed dependencies (reinstalled in-image; carrying host symlinks would
+# break the @AustinOrphan/* file: links which resolve to ../../packages/*).
+node_modules
+packages/*/node_modules
+
+# Build outputs (rebuilt in-image).
+dist
+build
+packages/*/dist
+coverage
+playwright-report
+test-results
+
+# VCS / CI / editor.
+.git
+.github
+.gitignore
+.vscode
+.idea
+
+# Local env & secrets — never bake into an image.
+.env
+.env.*
+!.env.example
+
+# Tests & docs not needed at build/runtime.
+tests
+e2e
+docs
+*.md
+!README.md
+
+# Tooling caches / logs.
+.remember
+*.log
+.DS_Store
+
+# The Dockerfiles themselves.
+Dockerfile*
+.dockerignore
+docker-compose*.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,82 +1,74 @@
-# Multi-stage Dockerfile for Running App
-# Stage 1: Dependencies
-FROM node:18-alpine AS deps
+# syntax=docker/dockerfile:1
+#
+# Backend image for the Running App.
+#
+# NOTE (unverified in-container): the install -> postinstall -> build -> boot
+# sequence is verified locally (npm ci; npm run build; `NODE_ENV=production
+# npx tsx server.ts` serves the SPA and /api/health). What is NOT verified
+# here is Docker itself (no daemon in the authoring env) — the stage copying
+# below is a reasoned draft, build it before relying on it.
+#
+# Key facts this image is built around:
+#  * The backend is NOT compiled. tsconfig has `noEmit: true`, so `tsc` only
+#    type-checks; the sole build output is the vite frontend in dist/, which
+#    server.ts serves statically in production. The server therefore runs from
+#    TypeScript source via tsx (a devDependency) — so this image ships devDeps.
+#  * The app depends on the vendored @AustinOrphan/{config,errors,logger}
+#    packages via `file:` links. node_modules/@AustinOrphan/* are symlinks to
+#    ../../packages/*, so packages/ must be present at the same relative path
+#    (with their built dist/) for both build and runtime.
+#  * The entrypoint runs `npx prisma migrate deploy`, so the Prisma CLI
+#    (a devDependency) must be present at runtime too.
+#  * engines requires Node >=20 (the old images pinned 18).
+
+# ---------- Stage 1: build ----------
+FROM node:20-alpine AS builder
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Copy dependency files
+# Manifests for the app AND the vendored packages, so the root `postinstall`
+# (which builds each package with `tsc`) and the `file:` links resolve.
 COPY package*.json ./
-COPY prisma ./prisma/
+COPY packages ./packages
+COPY prisma ./prisma
 
-# Install dependencies
-RUN npm ci --only=production
-RUN npm install -g prisma
-
-# Generate Prisma client
-RUN npx prisma generate
-
-# Stage 2: Builder
-FROM node:18-alpine AS builder
-RUN apk add --no-cache libc6-compat
-WORKDIR /app
-
-# Copy dependency files
-COPY package*.json ./
-COPY prisma ./prisma/
-
-# Install all dependencies (including dev)
+# Full install (incl. devDeps): the vendored packages build with `tsc`, which
+# resolves from the root node_modules; postinstall then builds them.
 RUN npm ci
 
-# Copy source code
+# Application source (node_modules/dist are excluded via .dockerignore, so this
+# does not clobber the install above or ship a stale build).
 COPY . .
 
-# Build arguments
 ARG NODE_ENV=production
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
-
-# Set build-time environment variables
 ENV NODE_ENV=${NODE_ENV}
 
-# Generate Prisma client
-RUN npx prisma generate
+# Generate the Prisma client and build the frontend that server.ts serves.
+RUN npx prisma generate \
+ && npm run build
 
-# Build the application
-RUN npm run build
-
-# Stage 3: Runner
-FROM node:18-alpine AS runner
+# ---------- Stage 2: runtime ----------
+FROM node:20-alpine AS runner
 RUN apk add --no-cache libc6-compat dumb-init
-
-# Create non-root user
-RUN addgroup -g 1001 -S nodejs
-RUN adduser -S nodejs -u 1001
-
+RUN addgroup -g 1001 -S nodejs && adduser -S nodejs -u 1001
 WORKDIR /app
 
-# Copy production dependencies from deps stage
-COPY --from=deps --chown=nodejs:nodejs /app/node_modules ./node_modules
-COPY --from=deps --chown=nodejs:nodejs /app/prisma ./prisma
+# Carry the fully-built tree from the builder. Because the backend runs from
+# source under tsx, the runtime needs node_modules (tsx + Prisma CLI + the
+# @AustinOrphan symlinks), packages/ (the symlink targets, with built dist/),
+# dist/ (frontend static assets), the TS source, prisma/, and scripts. Copying
+# /app wholesale keeps those pieces consistent and avoids missing-file drift.
+COPY --from=builder --chown=nodejs:nodejs /app /app
 
-# Copy built application from builder stage
-COPY --from=builder --chown=nodejs:nodejs /app/dist ./dist
-COPY --from=builder --chown=nodejs:nodejs /app/package*.json ./
-COPY --from=builder --chown=nodejs:nodejs /app/server.js ./server.js
-COPY --from=builder --chown=nodejs:nodejs /app/.env.example ./.env.example
-
-# Copy additional required files
-COPY --chown=nodejs:nodejs scripts/docker-entrypoint.sh ./scripts/
-COPY --chown=nodejs:nodejs scripts/health-check.js ./scripts/
-
-# Make scripts executable
+# Ensure the entrypoint is executable.
 RUN chmod +x ./scripts/docker-entrypoint.sh
 
-# Set runtime environment variables
 ENV NODE_ENV=production
 ENV PORT=3001
 
-# Add metadata labels
 LABEL org.opencontainers.image.title="Running App" \
       org.opencontainers.image.description="Full-stack running tracker application" \
       org.opencontainers.image.url="https://github.com/${GITHUB_REPOSITORY}" \
@@ -86,18 +78,13 @@ LABEL org.opencontainers.image.title="Running App" \
       org.opencontainers.image.revision="${VCS_REF}" \
       org.opencontainers.image.licenses="MIT"
 
-# Switch to non-root user
 USER nodejs
 
-# Expose port
 EXPOSE 3001
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
   CMD node ./scripts/health-check.js || exit 1
 
-# Use dumb-init to handle signals properly
+# dumb-init reaps zombies and forwards signals to the Node process.
 ENTRYPOINT ["dumb-init", "--"]
-
-# Start the application
 CMD ["./scripts/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,11 @@ COPY --from=builder --chown=nodejs:nodejs /app /app
 # Ensure the entrypoint is executable.
 RUN chmod +x ./scripts/docker-entrypoint.sh
 
+# Writable dir for the SQLite database file. Created (and chowned) in the image
+# so the compose named volume mounted here inherits nodejs ownership on first
+# use; otherwise the volume is root-owned and the non-root process can't write.
+RUN mkdir -p /app/data && chown nodejs:nodejs /app/data
+
 ENV NODE_ENV=production
 ENV PORT=3001
 

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,76 +1,72 @@
-# Frontend Dockerfile for Running App
-# Stage 1: Dependencies
-FROM node:18-alpine AS deps
+# syntax=docker/dockerfile:1
+#
+# Frontend image for the Running App: build the SPA with vite, serve with nginx.
+#
+# NOTE (unverified in-container): reasoned draft; no Docker daemon in the
+# authoring env. The frontend (src/) does NOT import the vendored
+# @AustinOrphan/* packages, so this image neither builds nor ships them:
+#  * `npm ci --ignore-scripts` skips the root postinstall (which would build
+#    the backend packages) — modern vite/rollup/esbuild ship their platform
+#    binaries via optionalDependencies, not install scripts, so the build is
+#    unaffected.
+#  * packages/ is still COPY'd because the lockfile's `file:` links reference
+#    packages/*/package.json; `npm ci` reads them to link, and errors if absent.
+#  * We run `vite build` directly rather than `npm run build`, because the
+#    latter's `tsc` step type-checks the whole repo (incl. the backend, whose
+#    @AustinOrphan type declarations we intentionally did not build here).
+#  * engines requires Node >=20 (the old image pinned 18).
+
+# ---------- Stage 1: build ----------
+FROM node:20-alpine AS builder
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
-# Copy dependency files
 COPY package*.json ./
+COPY packages ./packages
 
-# Install dependencies
-RUN npm ci
+RUN npm ci --ignore-scripts
 
-# Stage 2: Builder
-FROM node:18-alpine AS builder
-RUN apk add --no-cache libc6-compat
-WORKDIR /app
-
-# Copy dependencies from deps stage
-COPY --from=deps /app/node_modules ./node_modules
-COPY package*.json ./
-
-# Copy source code
 COPY . .
 
-# Build arguments
 ARG NODE_ENV=production
 ARG VITE_API_URL
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
-
-# Set build-time environment variables
 ENV NODE_ENV=${NODE_ENV}
 ENV VITE_API_URL=${VITE_API_URL}
 
-# Build the frontend application
-RUN npm run build
+# Frontend-only build (see note above on why not `npm run build`).
+RUN npx vite build
 
-# Stage 3: Production
+# ---------- Stage 2: serve ----------
 FROM nginx:alpine AS runner
+RUN apk add --no-cache curl jq bash
 
-# Install required packages
-RUN apk add --no-cache \
-    curl \
-    jq \
-    bash
-
-# Remove default nginx config
+# Custom nginx config (defines /, /api proxy, and /health used below).
 RUN rm -rf /etc/nginx/conf.d/*
-
-# Copy custom nginx configuration
 COPY nginx/default.conf /etc/nginx/conf.d/
 
-# Copy built application from builder stage
 COPY --from=builder /app/dist /usr/share/nginx/html
 
-# Copy environment variable injection script
-COPY scripts/inject-env-vars.sh /docker-entrypoint.d/20-inject-env-vars.sh
-RUN chmod +x /docker-entrypoint.d/20-inject-env-vars.sh
+# TODO(deploy): runtime env-var injection. The previous image referenced
+# scripts/inject-env-vars.sh, which does not exist in the repo, so the build
+# always failed here. It is commented out rather than reinvented, because the
+# placeholder scheme (which VITE_* vars, what token format) is unknown. Today
+# VITE_API_URL is baked at build time via the ARG above; restore this hook only
+# if you need per-deploy runtime overrides, and add the script alongside it.
+# COPY scripts/inject-env-vars.sh /docker-entrypoint.d/20-inject-env-vars.sh
+# RUN chmod +x /docker-entrypoint.d/20-inject-env-vars.sh
 
-# Add metadata labels
 LABEL org.opencontainers.image.title="Running App Frontend" \
       org.opencontainers.image.description="Frontend for Running App" \
       org.opencontainers.image.version="${VERSION}" \
       org.opencontainers.image.created="${BUILD_DATE}" \
       org.opencontainers.image.revision="${VCS_REF}"
 
-# Expose port
 EXPOSE 80
 
-# Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
   CMD curl -f http://localhost/health || exit 1
 
-# Start nginx
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,19 +58,22 @@ services:
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       PORT: ${PORT:-3001}
-      DATABASE_URL: postgresql://${DB_USER:-postgres}:${DB_PASSWORD:-postgres}@postgres:5432/${DB_NAME:-running_app}?schema=public
-      REDIS_URL: redis://:${REDIS_PASSWORD:-redis_password}@redis:6379
+      # The app uses Prisma with SQLite (see prisma/schema.prisma); the DB lives
+      # on the app-data volume. (postgres/redis services remain defined below but
+      # are not used by the app — neither is wired into the code.)
+      DATABASE_URL: file:/app/data/prod.db
+      # All three are required by config validation, which hard-exits on boot if
+      # any is missing/too short (JWT_SECRET >=32, LOG_SALT >=16). Supply them via
+      # .env (see .env.example).
       JWT_SECRET: ${JWT_SECRET}
+      SESSION_SECRET: ${SESSION_SECRET}
+      LOG_SALT: ${LOG_SALT}
       LOG_LEVEL: ${LOG_LEVEL:-info}
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-development}
     ports:
       - '${PORT:-3001}:3001'
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
     volumes:
+      - app-data:/app/data
       - ./logs:/app/logs
       - ./uploads:/app/uploads
     networks:
@@ -93,15 +96,14 @@ services:
     restart: unless-stopped
     environment:
       NODE_ENV: ${NODE_ENV:-development}
-      VITE_API_URL: http://backend:3001
+    # The nginx image listens on 80 (not 3000). The SPA calls the API via
+    # relative /api paths, which nginx proxies to backend:3001 (see
+    # nginx/default.conf), so no VITE_API_URL is needed.
     ports:
-      - '${FRONTEND_PORT:-3000}:3000'
+      - '${FRONTEND_PORT:-3000}:80'
     depends_on:
       backend:
         condition: service_healthy
-    volumes:
-      - ./src:/app/src:ro
-      - ./public:/app/public:ro
     networks:
       - app-network
 
@@ -198,6 +200,8 @@ networks:
         - subnet: 172.20.0.0/16
 
 volumes:
+  app-data:
+    driver: local
   postgres-data:
     driver: local
   redis-data:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "dev:full": "concurrently \"npm run dev\" \"npm run dev:frontend\"",
     "setup": "npm install && npx prisma migrate dev --name init && npx prisma generate",
     "build": "tsc && vite build",
-    "start": "node dist/server.js",
+    "start": "tsx server.ts",
     "preview": "vite preview",
     "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
     "lint:fix": "eslint . --ext .ts,.tsx,.js,.jsx --fix",

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -69,6 +69,10 @@ case "${DEPLOYMENT_MODE:-production}" in
     ;;
 esac
 
-# Start the application
+# Start the application.
+# The backend is not compiled to JS (tsconfig has noEmit: true — `tsc` only
+# type-checks; `vite build` emits the frontend into dist/). So we run the
+# TypeScript entrypoint directly with tsx, exactly as `npm run dev` does but
+# without --watch. tsx is a devDependency, so the image must carry devDeps.
 echo "🚀 Starting server on port ${PORT:-3001}..."
-exec node server.js
+exec npx tsx server.ts

--- a/scripts/health-check.js
+++ b/scripts/health-check.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const http = require('http');
+import http from 'node:http';
 
 const options = {
   hostname: 'localhost',
@@ -22,8 +22,11 @@ const req = http.request(options, res => {
       try {
         const health = JSON.parse(data);
 
-        // Check if all critical services are healthy
-        if (health.status === 'ok' && health.database?.status === 'connected') {
+        // The /api/health contract is { status: 'ok', timestamp }. If a
+        // database field is ever added, honor it too; otherwise `status: ok`
+        // (i.e. the server is up and serving) is the health signal.
+        const dbOk = health.database ? health.database.status === 'connected' : true;
+        if (health.status === 'ok' && dbOk) {
           console.log('✅ Health check passed');
           process.exit(0);
         } else {

--- a/server.ts
+++ b/server.ts
@@ -80,7 +80,9 @@ app.use('/api/analytics', analyticsRoutes);
 if (config.server.env === 'production') {
   app.use(express.static(path.join(__dirname, 'dist')));
 
-  app.get('*', (req, res) => {
+  // Express 5 (path-to-regexp v8) rejects the bare '*' wildcard; use a
+  // named splat so the SPA fallback route parses.
+  app.get('/*splat', (req, res) => {
     res.sendFile(path.join(__dirname, 'dist', 'index.html'));
   });
 }


### PR DESCRIPTION
## Summary

The Dockerfiles were broken independently of the (now-vendored) submodule issue, and — discovered while making the images buildable — **the production backend had never actually booted**. This branch reworks both images, fixes the prod-boot bugs, and aligns `docker-compose.yml` so the stack can actually run.

Depends on the vendoring work already on `main` (`packages/*`).

## Prod-boot bugs (verified fixed locally)

- **Express 5 wildcard**: `server.ts` used `app.get('*', …)`, which Express 5 (path-to-regexp v8) rejects at startup (`Missing parameter name`). Production-only block, so dev never hit it. Fixed to the named splat `/*splat`.
- **No compiled backend**: `tsconfig` has `noEmit: true`, so `npm run build` only type-checks + emits the vite frontend. The docker entrypoint and `npm start` both ran a nonexistent `server.js`. Both now run the TS source via **`tsx`**. tsx + Prisma CLI are devDeps, so the runtime image ships devDeps.
- **Broken healthcheck**: `scripts/health-check.js` used CommonJS `require()` in a `"type": "module"` package (always threw), and asserted a `database.status` field `/api/health` never returns (could never pass). Both fixed.

Verified locally (Docker itself is **unverified** — no daemon in the authoring env):
- `npm ci` → `npm run build`; `NODE_ENV=production npx tsx server.ts` → `/` serves the SPA, `/api/health` → 200, deep SPA routes fall back to `index.html`
- `node ./scripts/health-check.js` exits 0 against the running server

## Image changes

- **`.dockerignore`** (was missing) so `COPY . .` can't clobber the in-image install or ship stale host `node_modules`/`dist`.
- **`Dockerfile`** (backend): 2 stages, Node 20 (`engines >=20`, was 18). Copy `packages/` before `npm ci` so postinstall builds `@AustinOrphan/*` and the `file:` links resolve; carry `node_modules` + `packages/` + `dist/` + source to the runner. Create `/app/data` (nodejs-owned) for the sqlite volume.
- **`Dockerfile.frontend`**: Node 20; `npm ci --ignore-scripts` + `vite build`; `packages/` still copied for `file:` link resolution. Commented out the missing `scripts/inject-env-vars.sh` COPY with a TODO.

## docker-compose.yml — aligned to the sqlite app

- Backend `DATABASE_URL` → sqlite (`file:/app/data/prod.db`) on a new `app-data` volume; add `SESSION_SECRET`/`LOG_SALT` (required by config validation); drop unused `REDIS_URL` and the postgres/redis `depends_on` (neither is wired into the app). postgres/redis/pgadmin services remain defined but no longer gate boot.
- Frontend maps the published port to container **80** (nginx), drops the dead `VITE_API_URL` (SPA uses relative `/api`, proxied by nginx) and the meaningless source bind-mounts.

Docker `build`/`up` remains unverified (no daemon here) — please build before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)